### PR TITLE
Link in EN gefixt

### DIFF
--- a/src/pages/de/funktionsumfang.astro
+++ b/src/pages/de/funktionsumfang.astro
@@ -140,6 +140,11 @@ const description = 'Payflink bietet einen sehr grossen Leistungsumfang und ist 
           <p>Soll nur zu bestimmten Zeiten bestellt werden können? Sie können die Zeiten definieren, zu welchen bestellt
             werden kann.</p>
         </li>
+        <li style="list-style: '💶  ';">
+          <h3>Mindestbestellwert für Delivery</h3>
+          <p>Falls eine Lieferung nur ab einem gewissen Wert möglich sein soll, so kann der Mindestbestellwert im CMS 
+            definiert werden. Lieferbestellungen unter dem Mindestbestellwert sind dann nicht mehr möglich.</p>
+        </li>
         <li style="list-style: '🧾  ';">
           <h3>Quittung</h3>
           <p>Sollen die Gäste eine Quittung in Payflink erhalten, so können Sie die gewünschten Texte für die Quittung

--- a/src/pages/en/restaurant-order-app.mdx
+++ b/src/pages/en/restaurant-order-app.mdx
@@ -59,7 +59,7 @@ Depending on how the app is configured, guests pay each time they place an order
 At the end of the payment in the app, guests can download the receipt.
 
 <ButtonList>
-  <ButtonLink href="/en/funktionsumfang/">Functionality of the app</ButtonLink>
+  <ButtonLink href="/en/functions/">Functionality of the app</ButtonLink>
   {/* prettier-ignore */}
   {/* <ButtonLink href="/de/bestell-und-zahlungs-ablauf-gastro-betriebe/">Bestell- &amp; Zahlungsablauf</ButtonLink> */}
 </ButtonList>


### PR DESCRIPTION
Auf /en/restaurant-order-app gab es einen defekten link to /en/funktionsumfang